### PR TITLE
Template guidance docs and folders

### DIFF
--- a/docs/guidance/index.md
+++ b/docs/guidance/index.md
@@ -1,0 +1,15 @@
+# 📚 Guidance
+
+The aim of this folder is to share best-practice in RAM focus areas that projects at Turing (and beyond!) can peruse and utilise as they see fit.
+
+Please feel free to update/adapt/change anything within these files as new learning take place ⭐️
+
+## 🪜 Steps to create new guidance
+
+1. Create a new subfolder in the guidance folder with the title of your focus are, e.g. 'user-testing' or 'stakeholder-maps'
+
+2. Create two new files, `summary.md` and `turing_examples.md`
+
+3. Copy in the [template structure](./template.md) for each file.
+
+4. Add your content! 🚀

--- a/docs/guidance/template.md
+++ b/docs/guidance/template.md
@@ -1,0 +1,30 @@
+# 🔧 Guidance template
+
+Below is a template for creating RAM-related guidance. 
+
+Visit the [index](./index.md) file for info on how to use this template.
+
+## summary.md
+
+<!-- Copy this skeleton structure into your guidance file and adapt as required-->
+# Summary
+> High level one pager on things for people to consider
+
+# Contact
+> Generic information on how to get in touch with us for more questions
+
+# Resources
+> List of resources for people to deep-dive into
+
+<!-- Copy this skeleton structure into your guidance file and adapt as required-->
+
+## turing_examples.md
+
+<!-- Copy this skeleton structure into your guidance file and adapt as required-->
+# X activity at Turing
+> Summary of how to adapt general things above for Turing, e.g. event management speak to events team, can't host huge events etc.
+
+# Case studies
+> Examples of these activities that have taken place at Turing (either RAM-led or not)
+
+<!-- Copy this skeleton structure into your guidance file and adapt as required-->


### PR DESCRIPTION
Created the guidance folder as well as template and instructions on how to use - have separated out the basic 'Summary' (more article-y and info and resources) and what I've called 'Turing examples' (how to do this at Turing, as well as case studies), but better names could definitely be thought of!