### PR TITLE
[WIP] Start on onboarding docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/issue_template.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Use this form to submit an issue to the RAM repo that will appear as a task on the project board. Create an issue any time you wish to add a new file to the repo or make major changes.
   - type: textarea
-    id: descriptioj
+    id: description
     attributes:
       label: Provide a description
       description: What are you adding/changing and why?

--- a/.github/ISSUE_TEMPLATE/onboarding.md
+++ b/.github/ISSUE_TEMPLATE/onboarding.md
@@ -1,0 +1,19 @@
+---
+name: "\u1f91d Onboarding"
+about: An issue to track onboarding of a new RAM team member
+title:
+labels: [onboarding]
+assignees: ''
+
+---
+
+# [INSERT NAME] Onboarding
+
+- **Start date**: 
+- **RAM 'buddy'**: 
+- **RAM projects/programmes**: 
+
+Welcome to the RAM Team, [insert name] 💚
+Please use this issue to keep track of your onboarding tasks. 
+Once everything's been done, you can close this issue and dive fully into everything RAM 🏊‍♀️
+

--- a/onboarding/index.md
+++ b/onboarding/index.md
@@ -1,0 +1,32 @@
+# RAM Onboarding :rocket:
+
+Welcome to the Resesarch Application Manager Team! :tada:
+
+We're excited to have you join us and dive into the wonderful world of RAM.
+This file will lay out all the info you need to get started with your RAM life at Turing.
+
+## Contents
+
+- [Useful links](#useful-links)
+- [New starter checklist](#new-starter-checklist)
+
+## 🔗 Useful links
+
+* Find your onboarding issue in our [issue list](https://github.com/alan-turing-institute/research-application-management/labels/onboarding) - here is where we can track your progress with completing onboarding tasks
+
+
+## ✅ New starter checklist
+
+1. Bookmark this page and the other [useful links](#🔗-useful-links) above.
+2. **Onbarding sesions with RAM team**: Make sure you have the following introductory sessions arranged with different members of the RAM team. If you're not sure whether these have been arranged, chat to your RAM 'buddy'.
+    - **[General onboarding](./sessions/general_onboarding.md)**
+    - **[Introduction to RAM life](./sessions/ram_life.md)**
+    - **[Introduction to People and Teams](./sessions/people_and_teams.md)**
+    - **[Introduction to GitHub](./sessions/github.md)**: A session to introduce you to how the Turing uses GitHub, and all the relevant repos for you to get familiar with.
+
+3. **Access**: 
+4. **Reading**: Find the RAM reading on the [RAM Intro Reading HackMD](https://hackmd.io/NZTki1n_RPuQ7ml4WVVvHA)
+5. **Explore**: 
+6. **Relax with the team**: 
+
+

--- a/onboarding/index.md
+++ b/onboarding/index.md
@@ -13,12 +13,14 @@ This file will lay out all the info you need to get started with your RAM life a
 ## 🔗 Useful links
 
 * Find your onboarding issue in our [issue list](https://github.com/alan-turing-institute/research-application-management/labels/onboarding) - here is where we can track your progress with completing onboarding tasks
+* [The RAM Repo](https://github.com/alan-turing-institute/research-application-management)
+
 
 
 ## ✅ New starter checklist
 
 1. Bookmark this page and the other [useful links](#🔗-useful-links) above.
-2. **Onbarding sesions with RAM team**: Make sure you have the following introductory sessions arranged with different members of the RAM team. If you're not sure whether these have been arranged, chat to your RAM 'buddy'.
+2. **Onboarding sessions with RAM team**: Make sure you have the following introductory sessions arranged with different members of the RAM team. If you're not sure whether these have been arranged, chat to your RAM 'buddy'.
     - **[General onboarding](./sessions/general_onboarding.md)**
     - **[Introduction to RAM life](./sessions/ram_life.md)**
     - **[Introduction to People and Teams](./sessions/people_and_teams.md)**

--- a/onboarding/sessions/general_onboarding.md
+++ b/onboarding/sessions/general_onboarding.md
@@ -1,8 +1,26 @@
+# General Onboarding session
 
-* Turing Complete/Mathison
-* Turing events (e.g. catch-up)
-* Sharepoint
-* Turing org structure (inc useful people to meet, e.g. Academic Engagement, Parternships)
-* Training (Org training e.g. GDPR, plus training ops e.g. DSGs, OLS etc.)
-* WFH equipment
-* Communication channels - Slack
+This file contains the information to cover in the general onboarding session for a new RAM member!
+This session should probably be one of the first sessions the new team member does.
+
+Time required: 1 hour
+
+## Before the session
+- Touch base with their project team to find out where they store any useful resources. Collate these into a pack for the new starter!
+
+## During the session
+
+### General setup (15 mins)
+- Help them determine what Work From Home equipment they need, and request it from IT
+- Introduce the [Turing learning platform](https://turing.learnupon.com/dashboard) and flag that they need to complete the required training
+- Make sure they're on the invite for general Turing events e.g. Turing Town Halls.
+- Run them through the hgih level Turing org structure 
+
+### Tools (15 mins)
+- Introduce Turing Complete/Mathison
+- Help them to set up an HR onboarding session (if it's not been arranged yet)
+- Introduce them to SharePoint, especially the [RAM Sharepoint](https://thealanturininstitute.sharepoint.com/sites/RAM)
+
+## After the session
+
+Be a friendly point of contact for any Turing questions they may have!

--- a/onboarding/sessions/general_onboarding.md
+++ b/onboarding/sessions/general_onboarding.md
@@ -1,0 +1,8 @@
+
+* Turing Complete/Mathison
+* Turing events (e.g. catch-up)
+* Sharepoint
+* Turing org structure (inc useful people to meet, e.g. Academic Engagement, Parternships)
+* Training (Org training e.g. GDPR, plus training ops e.g. DSGs, OLS etc.)
+* WFH equipment
+* Communication channels - Slack

--- a/onboarding/sessions/github.md
+++ b/onboarding/sessions/github.md
@@ -3,7 +3,7 @@
 This file contains the information to cover in the GitHub onboarding session for a new RAM member!
 This session should probably take place after the sessions introducing them to TPS-associated projects, like the Turing Way and Whitaker Lab, as well as 'RAM life'
 
-Time required: 30 mins
+Time required: 45 mins
 
 ## Before the session
 * Find out which projects they're working on. Ensure that, as part of the projects' onboarding plans, they have set aside specific time to introduce them to the GitHub repos the project works with.
@@ -27,7 +27,7 @@ Time required: 30 mins
     - **[Whitaker Lab](https://github.com/WhitakerLab)**
         - Add them to the repo
         - Create a folder for them in `weekly-updates`, and describe to them how this works
-    - **[Reproducible project template]**
+    - **[Reproducible project template](https://github.com/alan-turing-institute/reproducible-project-template)**
         - Introduce them to this template, and why it could be useful to them on their projects
 * Help them coordinate GitHub onboarding sessions for their projects
 

--- a/onboarding/sessions/github.md
+++ b/onboarding/sessions/github.md
@@ -1,0 +1,36 @@
+# GitHub onboarding session
+
+This file contains the information to cover in the GitHub onboarding session for a new RAM member!
+This session should probably take place after the sessions introducing them to TPS-associated projects, like the Turing Way and Whitaker Lab, as well as 'RAM life'
+
+Time required: 30 mins
+
+## Before the session
+* Find out which projects they're working on. Ensure that, as part of the projects' onboarding plans, they have set aside specific time to introduce them to the GitHub repos the project works with.
+
+## During the session
+
+* Make sure they have a GitHub account (create one if required).
+* Get them to sign up to become a member of the Alan Turing Institute Organisation on GitHub via [this form](https://turingcomplete.topdesk.net/tas/public/ssp/content/serviceflow?unid=3844fabf8b1c45ca9028758a350ff230&from=c56ec576-4ee8-4b07-8bde-9f9f45b6d561&openedFromService=true)
+* If they're not familiar with GitHub, help them to organise a GitHub onboarding/training session. A good place to start is reach out to the Turing Way team to see whether any Intro to GitHub sessions are running soon - if not there are recordings of sessions they can watch!
+* Introduce them to the main repos they will need to familairise themselves with on a RAM side:
+    - **[Turing Way](https://github.com/alan-turing-institute/the-turing-way)**
+        - Add them as a collaborator
+        - Introduce the book
+        - Tasks for them to complete:
+            - Read through the README, CONTRIBUTING, CODE_OF_CONDUCT (and more if it interests them!)
+            - Add their name to `contributors.md`
+    - **[RAM Repo](https://github.com/alan-turing-institute/research-application-management)**
+        - Add them to the repo
+        - Walk through the project board
+        - Describe what the repo is for
+    - **[Whitaker Lab](https://github.com/WhitakerLab)**
+        - Add them to the repo
+        - Create a folder for them in `weekly-updates`, and describe to them how this works
+    - **[Reproducible project template]**
+        - Introduce them to this template, and why it could be useful to them on their projects
+* Help them coordinate GitHub onboarding sessions for their projects
+
+## After the session
+
+Be a friendly point of contact for any GitHub questions they may have!

--- a/onboarding/sessions/people_and_teams.md
+++ b/onboarding/sessions/people_and_teams.md
@@ -1,0 +1,6 @@
+
+* TPS
+* WL
+* Turing Way
+* Bios
+* Communication channels - Slack

--- a/onboarding/sessions/people_and_teams.md
+++ b/onboarding/sessions/people_and_teams.md
@@ -1,6 +1,7 @@
 
 * TPS
 * WL
+    * Organise i WL/TPS coffee for intros
 * Turing Way
 * Bios
 * Communication channels - Slack

--- a/onboarding/sessions/people_and_teams.md
+++ b/onboarding/sessions/people_and_teams.md
@@ -1,7 +1,64 @@
 
-* TPS
-* WL
-    * Organise i WL/TPS coffee for intros
 * Turing Way
-* Bios
 * Communication channels - Slack
+
+# People & Teams Onboarding session
+
+This file contains the information to cover in the people & teams onboarding session for a new RAM member!
+This session should probably be one of the first sessions the new team member does
+
+Time required: 1 hour
+
+## Before the session
+- Find a WL coffee chat in the week they are starting that a majority of the Lab can make to say hi - Ideally this would be on their first day but could be a different day if needed!
+- Ensure someone from theproject teams they'll be joining is set-up to onboard them to the project, and will help them meet everyone on the team
+
+## During the session
+
+### TPS (10 mins)
+- Introduce [TPS](https://www.turing.ac.uk/research/research-programmes/tools-practices-and-systems), including the [impact story](https://www.turing.ac.uk/research/impact-stories/changing-culture-data-science)
+- Introduce TPS coffee chats, and ensure they are on the invite for the event
+- TPS Org chart? Or at least meet the main people
+    - Kirstie Whitaker
+    - Arielle Bennett
+    - Malvika Sharan
+- Ensure they have access to the `#tps` Slack channel
+Introduce them on the Slack channel
+
+### Whitaker Lab (10 mins)
+- Introduce the concept of Whitaker Lab
+- Ensure they have access to the `#whitaker-lab` Slack channel, and the accompanying `#whitaker-lab-socials` & `#whitakerlab-checkin` channels.
+- Introduce them on the main Slack channel
+- Invite them to the Whitaker Lab coffee events, and Whitaker lab meetings on Thursdays (and make sure they attend the intro coffee chat mentioned above)
+- Share the [Whitaker Lab note of notes](https://hackmd.io/@whitakerlab/note-of-notes)
+- Show them the [WL members intro slide deck](https://docs.google.com/presentation/d/1g-plncmi00FK97QuYDfqq7oPzUmL0xkHm1hy4X81IX8/edit#slide=id.gf5e62e1b31_1_0) and ask them to create their own slide
+
+### Turing Way (10 mins)
+- Introduce the [Turing Way](https://the-turing-way.netlify.app/welcome)
+- Reach out to Anne to set up an introduction to everything Turing Way
+- Ensure they are added to the relevant Turing Way meetings
+    - Coworking (Weekly Monday 11am)
+    - Collaboration cafes (Monthly Wednesday 3pm)
+    - Core team meeting (Tri-monthly Friday 3pm)
+- Add them to the Slack workspace and get them to introduce themselves in `#introductions`
+
+### Turing teams (15 mins)
+- Highlight the different groups in Turing the RAM team spends time collaborating with.
+- Introduce them to the groups below (and more if you can think of them), & help them reach out to the respective contacts to set up an introductory chat.
+    - Partnerships - Katrina Payne
+    - Comms - ?
+    - Impact - Simon Reeve/Chris Charlton-Matthews
+    - Events - ?
+    - Others?
+
+### Other Slack channels (5 mins)
+- Alert them to all the different slack channels you can join at Turing (by hovering over `Channels` and clicking `+` -> `Browse channels`).
+- Let them know how they can manage their slack notifications - and probably turn on notifications for the RAM channel
+
+### Team social (5 min)
+- Explore a time when they are free the newly expanded RAM team can go on a social together! A drink after work or lunch, or anything else that makes sense! 
+
+## After the session
+
+Be a friendly point of contact for any people/group questions they may have!
+If you realise more people they should meet, help them set those meetings up!

--- a/onboarding/sessions/ram_life.md
+++ b/onboarding/sessions/ram_life.md
@@ -1,0 +1,33 @@
+# RAM Life Onboarding session
+
+This file contains the information to cover in the RAM life onboarding session for a new RAM member!
+This session should probably be one of the first sessions the new team member does
+
+Time required: 1 hour
+
+## Before the session
+* 
+
+## During the session
+
+### Introduce tools (20 mins)
+* Introduce, and help them familiarse themselves with, the following tools
+    * HackMD
+    * SharePoint
+    * The RAM website
+
+### Introduce RAM resources (40 mins)
+* Give them a brief history of RAMs at Turing
+* If they have not already read the RAM paper, direct them towards it. If they have, ask if they have any questions about it
+* Make sure they have access to the [RAM SharePoint](https://thealanturininstitute.sharepoint.com/sites/RAM/Shared%20Documents/Forms/AllItems.aspx). Talk them through it's different components.
+* Alert them to the [RAM repo](https://github.com/alan-turing-institute/research-application-management). Let them know they'll go through this in more detail in their [intro to GitHub](./github.md) session.
+* Help them setup website editing training session
+* Add them as an 'Organiser' to the [RAM webpage](https://www.turing.ac.uk/research/research-programmes/tools-practices-and-systems/research-application-management) and their project webpages. Either do this manually on the website (if you know how!), or via the [add new researcher form](https://turingcomplete.topdesk.net/tas/public/ssp/content/serviceflow?unid=35b8d40067004f9484c9fb06ade41d65) and [Request website content change form](https://turingcomplete.topdesk.net/tas/public/ssp/content/serviceflow?unid=3ed00cd98cfb4aedb8972ad1bc53cc3d)
+* Introduce them to the [RAM HackMD](https://hackmd.io/team/TuringRAMs?nav=overview), and run through the RAM schedule including:
+    - RAM Team meetings
+    - RAM coworking
+
+
+## After the session
+
+Be a friendly point of contact for any GitHub questions they may have!

--- a/onboarding/sessions/ram_life.md
+++ b/onboarding/sessions/ram_life.md
@@ -6,7 +6,7 @@ This session should probably be one of the first sessions the new team member do
 Time required: 1 hour
 
 ## Before the session
-* 
+* Nothing to prep!
 
 ## During the session
 
@@ -18,16 +18,18 @@ Time required: 1 hour
 
 ### Introduce RAM resources (40 mins)
 * Give them a brief history of RAMs at Turing
-* If they have not already read the RAM paper, direct them towards it. If they have, ask if they have any questions about it
+* If they haven't already read the RAM paper, direct them towards it. If they have, ask if they have any questions about it
 * Make sure they have access to the [RAM SharePoint](https://thealanturininstitute.sharepoint.com/sites/RAM/Shared%20Documents/Forms/AllItems.aspx). Talk them through it's different components.
 * Alert them to the [RAM repo](https://github.com/alan-turing-institute/research-application-management). Let them know they'll go through this in more detail in their [intro to GitHub](./github.md) session.
-* Help them setup website editing training session
+* Help them set up a website editing training session
+* Help them set up a CRM training session
 * Add them as an 'Organiser' to the [RAM webpage](https://www.turing.ac.uk/research/research-programmes/tools-practices-and-systems/research-application-management) and their project webpages. Either do this manually on the website (if you know how!), or via the [add new researcher form](https://turingcomplete.topdesk.net/tas/public/ssp/content/serviceflow?unid=35b8d40067004f9484c9fb06ade41d65) and [Request website content change form](https://turingcomplete.topdesk.net/tas/public/ssp/content/serviceflow?unid=3ed00cd98cfb4aedb8972ad1bc53cc3d)
 * Introduce them to the [RAM HackMD](https://hackmd.io/team/TuringRAMs?nav=overview), and run through the RAM schedule including:
     - RAM Team meetings
     - RAM coworking
+* Point them towards the [RAM Intro reading](https://hackmd.io/NZTki1n_RPuQ7ml4WVVvHA)
 
 
 ## After the session
 
-Be a friendly point of contact for any GitHub questions they may have!
+Be a friendly point of contact for any RAM-y questions they may have!


### PR DESCRIPTION
Will continue working on this next week! Initial thoughts are:

- Create an issue that new starter can treat as a checklist for onboarding
- One team member to be 'Point of Contact' or 'Buddy' for new starter
- Sessions with different members of RAM team introducing them to different parts of Turing/RAM
- Arrange a social session with the team
- Do some liaising with their project teams before they start to ensure they have onboarding in place already

## Things that need looking at in the docs
- Who the people are they should meet in wider Turing in `People and teams` onboarding
- Creation (or identification) of intro to Turing resources (e.g. org charts)